### PR TITLE
Add patch for the fix of escaping of arguments passed to LaunchProcess() in JavaBinaryLauncher::CreateClasspathJar on Windows

### DIFF
--- a/patches/0005-Fix_escaping_of_arguments_passed_to_LaunchProcess___in_JavaBinaryLauncher__CreateClasspath.patch
+++ b/patches/0005-Fix_escaping_of_arguments_passed_to_LaunchProcess___in_JavaBinaryLauncher__CreateClasspath.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] Fix escaping of arguments passed to LaunchProcess() in JavaBinaryLauncher::CreateClasspathJar on Windows
+---
+Index: src/tools/launcher/java_launcher.cc
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/tools/launcher/java_launcher.cc b/src/tools/launcher/java_launcher.cc
+--- a/src/tools/launcher/java_launcher.cc	(revision 33650c6ba5589643503ae240aa67e6527713f33e)
++++ b/src/tools/launcher/java_launcher.cc	(date 1753388457972)
+@@ -280,8 +280,8 @@
+   wstring jar_bin = this->Rlocation(this->GetLaunchInfoByKey(JAR_BIN_PATH));
+   vector<wstring> arguments;
+   arguments.push_back(L"cvfm");
+-  arguments.push_back(manifest_jar_path);
+-  arguments.push_back(jar_manifest_file_path);
++  arguments.push_back(bazel::windows::WindowsEscapeArg(manifest_jar_path));
++  arguments.push_back(bazel::windows::WindowsEscapeArg(jar_manifest_file_path));
+ 
+   if (this->LaunchProcess(jar_bin, arguments, /* suppressOutput */ true) != 0) {
+     die(L"Couldn't create classpath jar: %s", manifest_jar_path.c_str());


### PR DESCRIPTION
It's necessary to properly work in the case when project path contains spaces on Windows and classpath jar is required. See [IJI-2928]( https://youtrack.jetbrains.com/issue/IJI-2928/Bazel-support-project-root-with-spaces-under-Windows).