### PR TITLE
allow network-inbound to workaround binding issues on ipv4 localhost in darwin-sandbox

### DIFF
--- a/patches/0006-allow_network-inbound_to_workaround_binding_on_ipv4_localhost_in_darwin-sandbox.patch
+++ b/patches/0006-allow_network-inbound_to_workaround_binding_on_ipv4_localhost_in_darwin-sandbox.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] allow network-inbound to workaround binding on ipv4 localhost in darwin-sandbox
+---
+Index: src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java
+--- a/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java	(revision 615b63dd005923e12e1356c1368e80dd121f2c5a)
++++ b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java	(date 1754296277776)
+@@ -298,7 +298,7 @@
+ 
+       if (!allowNetwork) {
+         out.println("(deny network*)");
+-        out.println("(allow network-inbound (local ip \"localhost:*\"))");
++        out.println("(allow network-inbound (local ip \"*:*\"))");
+         out.println("(allow network* (remote ip \"localhost:*\"))");
+         out.println("(allow network* (remote unix-socket))");
+       }


### PR DESCRIPTION
For reasons only Apple knows, you cannot bind to IPv4-localhost when you run in a sandbox that only allows loopback traffic, but binding to IPv6-localhost works fine. With this patch we will be able to bind on IPv4-localhost as it's required to run sandboxed debugger tests.

see examples of the same problem:
https://github.com/bazelbuild/bazel/blob/1f2d57631df9c61f0a15775cad72dc415a037ee4/src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java#L414-L447
https://cs.opensource.google/bazel/bazel/+/6b8c7ca48e9e48a9906c031346dc4a924b7ef559:src/main/java/com/google/devtools/build/lib/server/GrpcServerImpl.java;l=691