### PR TITLE
Migrate to macos-15-intel runner when building on macOS x64 in .github/workflows/on-push.yml

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -53,7 +53,7 @@ jobs:
             exe: ''
             artifact_os: linux
             artifact_arch: arm64
-          - runner: macos-14
+          - runner: macos-15-intel
             exe: ''
             artifact_os: darwin
             artifact_arch: x86_64


### PR DESCRIPTION
macos-14 is ARM64.

https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories